### PR TITLE
Bug fix: can't find strings of digits

### DIFF
--- a/src/MultiStringMatcher.php
+++ b/src/MultiStringMatcher.php
@@ -173,6 +173,7 @@ class MultiStringMatcher {
 		$this->outputs = [ [] ];
 		foreach ( $this->searchKeywords as $keyword => $length ) {
 			$state = 0;
+			$keyword = (string)$keyword;
 			for ( $i = 0; $i < $length; $i++ ) {
 				$ch = $keyword[$i];
 				if ( !empty( $this->yesTransitions[$state][$ch] ) ) {


### PR DESCRIPTION
php converts array string keys into integers when possible, causing the $keyword variable in foreach loop to be of type int for strings like '123'.
My change makes sure $keyword will be a string, preventing failure when trying to get $keyword[$i] and ensuring the output will be of type string.