### PR TITLE
Fixes any numeric search term causes error.

### DIFF
--- a/src/MultiStringMatcher.php
+++ b/src/MultiStringMatcher.php
@@ -172,6 +172,9 @@ class MultiStringMatcher {
 		$this->yesTransitions = [ [] ];
 		$this->outputs = [ [] ];
 		foreach ( $this->searchKeywords as $keyword => $length ) {
+
+            $keyword = strval( $keyword );
+
 			$state = 0;
 			for ( $i = 0; $i < $length; $i++ ) {
 				$ch = $keyword[$i];

--- a/tests/AhoCorasickTest.php
+++ b/tests/AhoCorasickTest.php
@@ -61,6 +61,13 @@ class AhoCorasickTest extends \PHPUnit\Framework\TestCase {
 				'She sells sea shells by the sea shore.',
 				[ 's', 'se', 'sea', 'ore', 'hell', 'eat' ]
 			],
+
+            [
+                'She sells 100 sea shells by the sea shore.',
+                [ 's', 'se', 'sea', 'ore', 'hell', 'eat', '100' ]
+
+            ],
+
 			[
 				'She sells sea shells by the sea shore.',
 				[ 's', 'ls', 'lls', 'hells', 'shell', 'she', 'he', 'h' ],

--- a/tests/NaiveMultiStringMatcher.php
+++ b/tests/NaiveMultiStringMatcher.php
@@ -46,6 +46,7 @@ class NaiveMultiStringMatcher extends MultiStringMatcher {
 		$matches = [];
 		foreach ( $this->searchKeywords as $keyword => $length ) {
 			$offset = 0;
+            $keyword = strval( $keyword );
 			while ( true ) {
 				$offset = strpos( $text, $keyword, $offset );
 				if ( $offset === false ) {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T301632

This fixes attempting to use a numeric string as a search term causes an error and stops the MultiStringMatcher object from being created.
